### PR TITLE
ci: enable dependabot for deno and make bundle reproducible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
       actions:
         patterns:
           - "*"
+  - package-ecosystem: "deno"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      deno:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -2,7 +2,7 @@ name: Auto Update
 
 on:
   schedule:
-    - cron: "0 0 1 * *" # at midnight on the first day of each month
+    - cron: "0 0 1 */3 *" # at midnight on the first day of every third month
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
-/npm
+/npm/*
+!/npm/package-lock.json

--- a/dist/main.js
+++ b/dist/main.js
@@ -1310,14 +1310,14 @@ var require_util = __commonJS({
       if (ReadableStream.from) {
         return ReadableStream.from(convertIterableToBuffer(iterable));
       }
-      let iterator2;
+      let iterator3;
       return new ReadableStream(
         {
           async start() {
-            iterator2 = iterable[Symbol.asyncIterator]();
+            iterator3 = iterable[Symbol.asyncIterator]();
           },
           async pull(controller) {
-            const { done, value } = await iterator2.next();
+            const { done, value } = await iterator3.next();
             if (done) {
               queueMicrotask(() => {
                 controller.close();
@@ -1329,7 +1329,7 @@ var require_util = __commonJS({
             return controller.desiredSize > 0;
           },
           async cancel(reason) {
-            await iterator2.return();
+            await iterator3.return();
           }
         },
         0
@@ -4167,11 +4167,11 @@ var require_util2 = __commonJS({
       return result;
     }
     var esIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
-    function makeIterator(iterator2, name, kind) {
+    function makeIterator(iterator3, name, kind) {
       const object = {
         index: 0,
         kind,
-        target: iterator2
+        target: iterator3
       };
       const i = {
         next() {
@@ -5496,13 +5496,13 @@ Content-Type: ${value.type || "application/octet-stream"}\r
         length = Buffer.byteLength(source);
       }
       if (action != null) {
-        let iterator2;
+        let iterator3;
         stream = new ReadableStream({
           async start() {
-            iterator2 = action(object)[Symbol.asyncIterator]();
+            iterator3 = action(object)[Symbol.asyncIterator]();
           },
           async pull(controller) {
-            const { value, done } = await iterator2.next();
+            const { value, done } = await iterator3.next();
             if (done) {
               queueMicrotask(() => {
                 controller.close();
@@ -5515,7 +5515,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
             return controller.desiredSize > 0;
           },
           async cancel(reason) {
-            await iterator2.return();
+            await iterator3.return();
           },
           type: void 0
         });
@@ -13854,8 +13854,8 @@ var require_fetch = __commonJS({
         if (socket) {
           response = makeResponse({ status, statusText, headersList, socket });
         } else {
-          const iterator2 = body[Symbol.asyncIterator]();
-          fetchParams.controller.next = () => iterator2.next();
+          const iterator3 = body[Symbol.asyncIterator]();
+          fetchParams.controller.next = () => iterator3.next();
           response = makeResponse({ status, statusText, headersList });
         }
       } catch (err) {
@@ -23523,14 +23523,17 @@ var require_dist = __commonJS({
       return result;
     }
     function parse3(header, options) {
+      const stopChar = options?.comma === true ? COMMA : 65536;
       const len = header.length;
-      let index = skipOWS(header, 0, len);
+      let index = skipOWS(header, options?.start ?? 0, len);
       const valueStart = index;
-      index = skipValue(header, index, len);
+      index = skipValue(header, index, len, stopChar);
       const valueEnd = trailingOWS(header, valueStart, index);
       const type = header.slice(valueStart, valueEnd).toLowerCase();
-      const parameters = options?.parameters === false ? new NullObject() : parseParameters(header, index, len);
-      return { type, parameters };
+      if (options?.parameters === false) {
+        return { type, index, parameters: new NullObject() };
+      }
+      return parseParameters(header, type, index, len, stopChar);
     }
     var SP = 32;
     var HTAB = 9;
@@ -23538,13 +23541,18 @@ var require_dist = __commonJS({
     var EQ = 61;
     var DQUOTE = 34;
     var BSLASH = 92;
-    function parseParameters(header, index, len) {
+    var COMMA = 44;
+    function parseParameters(header, type, index, len, stopChar) {
       const parameters = new NullObject();
       parameter: while (index < len) {
+        if (header.charCodeAt(index) === stopChar)
+          break;
         index = skipOWS(header, index + 1, len);
         const keyStart = index;
         while (index < len) {
           const code = header.charCodeAt(index);
+          if (code === stopChar)
+            break parameter;
           if (code === SEMI)
             continue parameter;
           if (code === EQ) {
@@ -23557,7 +23565,7 @@ var require_dist = __commonJS({
               while (index < len) {
                 const code2 = header.charCodeAt(index++);
                 if (code2 === DQUOTE) {
-                  index = skipValue(header, index, len);
+                  index = skipValue(header, index, len, stopChar);
                   if (parameters[key] === void 0)
                     parameters[key] = value;
                   break;
@@ -23571,7 +23579,7 @@ var require_dist = __commonJS({
               continue parameter;
             }
             const valueStart = index;
-            index = skipValue(header, index, len);
+            index = skipValue(header, index, len, stopChar);
             if (parameters[key] === void 0) {
               const valueEnd = trailingOWS(header, valueStart, index);
               parameters[key] = header.slice(valueStart, valueEnd);
@@ -23581,12 +23589,12 @@ var require_dist = __commonJS({
           index++;
         }
       }
-      return parameters;
+      return { type, index, parameters };
     }
-    function skipValue(str, index, len) {
+    function skipValue(str, index, len, stopChar) {
       while (index < len) {
-        const char = str.charCodeAt(index);
-        if (char === SEMI)
+        const code = str.charCodeAt(index);
+        if (code === SEMI || code === stopChar)
           break;
         index++;
       }
@@ -24125,7 +24133,10 @@ async function getResponseData(response) {
     } catch (err) {
       return text;
     }
-  } else if (mimetype.type.startsWith("text/") || mimetype.parameters.charset?.toLowerCase() === "utf-8") {
+  } else if (mimetype.type.startsWith("text/") || // `application/octet-stream` is the canonical "arbitrary binary" type
+  // (RFC 2046) and must never be decoded as text, even when the response
+  // carries a (misleading) `charset=utf-8` parameter — see #751.
+  mimetype.parameters.charset?.toLowerCase() === "utf-8" && mimetype.type !== "application/octet-stream") {
     return response.text().catch(noop);
   } else {
     return response.arrayBuffer().catch(
@@ -24182,7 +24193,7 @@ var init_dist_bundle2 = __esm({
     import_content_type = __toESM(require_dist(), 1);
     init_json_with_bigint();
     init_dist_src();
-    VERSION2 = "10.0.11";
+    VERSION2 = "10.0.13";
     defaults_default = {
       headers: {
         "user-agent": `octokit-request.js/${VERSION2} ${getUserAgent()}`
@@ -24281,6 +24292,9 @@ var init_dist_bundle3 = __esm({
           Error.captureStackTrace(this, this.constructor);
         }
       }
+      request;
+      headers;
+      response;
       name = "GraphqlResponseError";
       errors;
       data;
@@ -24361,7 +24375,7 @@ var init_dist_bundle4 = __esm({
 var VERSION4;
 var init_version = __esm({
   "npm/node_modules/@octokit/core/dist-src/version.js"() {
-    VERSION4 = "7.0.6";
+    VERSION4 = "7.0.7";
   }
 });
 
@@ -24595,8 +24609,8 @@ function paginate(octokit, route, parameters, mapFn) {
     mapFn
   );
 }
-function gather(octokit, results, iterator2, mapFn) {
-  return iterator2.next().then((result) => {
+function gather(octokit, results, iterator22, mapFn) {
+  return iterator22.next().then((result) => {
     if (result.done) {
       return results;
     }
@@ -24610,7 +24624,7 @@ function gather(octokit, results, iterator2, mapFn) {
     if (earlyExit) {
       return results;
     }
-    return gather(octokit, results, iterator2, mapFn);
+    return gather(octokit, results, iterator22, mapFn);
   });
 }
 function paginateRest(octokit) {
@@ -24782,10 +24796,10 @@ var init_dist_bundle6 = __esm({
       return response1;
     };
     createPaginate = (octokit) => {
-      const iterator2 = createIterator(octokit);
+      const iterator3 = createIterator(octokit);
       return async (query, initialParameters = {}) => {
         let mergedResponse = {};
-        for await (const response of iterator2(
+        for await (const response of iterator3(
           query,
           initialParameters
         )) {
@@ -28720,18 +28734,13 @@ function throttling(octokit, octokitOptions) {
   if (typeof connection !== "undefined") {
     common.connection = connection;
   }
-  if (groups.global == null) {
-    createGroups(Bottleneck2, common);
-  }
   const state = Object.assign(
     {
       clustering: connection != null,
       triggersNotification,
       fallbackSecondaryRateRetryAfter: 60,
       retryAfterBaseValue: 1e3,
-      retryLimiter: new Bottleneck2(),
-      id,
-      ...groups
+      id
     },
     octokitOptions.throttle
   );
@@ -28748,65 +28757,84 @@ function throttling(octokit, octokitOptions) {
         })
     `);
   }
-  const events = {};
-  const emitter = new Bottleneck2.Events(events);
-  events.on("secondary-limit", state.onSecondaryRateLimit);
-  events.on("rate-limit", state.onRateLimit);
-  events.on(
-    "error",
-    (e) => octokit.log.warn("Error in throttling-plugin limit handler", e)
-  );
-  state.retryLimiter.on("failed", async function(error, info) {
-    const [state2, request2, options] = info.args;
-    const { pathname } = new URL(options.url, "http://github.test");
-    const shouldRetryGraphQL = pathname.startsWith("/graphql") && error.status !== 401;
-    if (!(shouldRetryGraphQL || error.status === 403 || error.status === 429)) {
+  let initialized = false;
+  const initializeBottleneck = () => {
+    if (initialized) {
       return;
     }
-    const retryCount = ~~request2.retryCount;
-    request2.retryCount = retryCount;
-    options.request.retryCount = retryCount;
-    const { wantRetry, retryAfter = 0 } = await (async function() {
-      if (/\bsecondary rate\b/i.test(error.message)) {
-        const retryAfter2 = Number(error.response.headers["retry-after"]) || state2.fallbackSecondaryRateRetryAfter;
-        const wantRetry2 = await emitter.trigger(
-          "secondary-limit",
-          retryAfter2,
-          options,
-          octokit,
-          retryCount
-        );
-        return { wantRetry: wantRetry2, retryAfter: retryAfter2 };
-      }
-      if (error.response.headers != null && error.response.headers["x-ratelimit-remaining"] === "0" || (error.response.data?.errors ?? []).some(
-        (error2) => error2.type === "RATE_LIMITED"
-      )) {
-        const rateLimitReset = new Date(
-          ~~error.response.headers["x-ratelimit-reset"] * 1e3
-        ).getTime();
-        const retryAfter2 = Math.max(
-          // Add one second so we retry _after_ the reset time
-          // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
-          Math.ceil((rateLimitReset - Date.now()) / 1e3) + 1,
-          0
-        );
-        const wantRetry2 = await emitter.trigger(
-          "rate-limit",
-          retryAfter2,
-          options,
-          octokit,
-          retryCount
-        );
-        return { wantRetry: wantRetry2, retryAfter: retryAfter2 };
-      }
-      return {};
-    })();
-    if (wantRetry) {
-      request2.retryCount++;
-      return retryAfter * state2.retryAfterBaseValue;
+    initialized = true;
+    if (groups.global == null) {
+      createGroups(Bottleneck2, common);
     }
+    state.global = state.global ?? groups.global;
+    state.auth = state.auth ?? groups.auth;
+    state.search = state.search ?? groups.search;
+    state.write = state.write ?? groups.write;
+    state.notifications = state.notifications ?? groups.notifications;
+    state.retryLimiter = state.retryLimiter ?? new Bottleneck2();
+    const events = {};
+    const emitter = new Bottleneck2.Events(events);
+    events.on("secondary-limit", state.onSecondaryRateLimit);
+    events.on("rate-limit", state.onRateLimit);
+    events.on(
+      "error",
+      (e) => octokit.log.warn("Error in throttling-plugin limit handler", e)
+    );
+    state.retryLimiter.on("failed", async function(error, info) {
+      const [state2, request2, options] = info.args;
+      const { pathname } = new URL(options.url, "http://github.test");
+      const shouldRetryGraphQL = pathname.startsWith("/graphql") && error.status !== 401;
+      if (!(shouldRetryGraphQL || error.status === 403 || error.status === 429)) {
+        return;
+      }
+      const retryCount = ~~request2.retryCount;
+      request2.retryCount = retryCount;
+      options.request.retryCount = retryCount;
+      const { wantRetry, retryAfter = 0 } = await (async function() {
+        if (/\bsecondary rate\b/i.test(error.message)) {
+          const retryAfter2 = Number(error.response.headers["retry-after"]) || state2.fallbackSecondaryRateRetryAfter;
+          const wantRetry2 = await emitter.trigger(
+            "secondary-limit",
+            retryAfter2,
+            options,
+            octokit,
+            retryCount
+          );
+          return { wantRetry: wantRetry2, retryAfter: retryAfter2 };
+        }
+        if (error.response.headers != null && error.response.headers["x-ratelimit-remaining"] === "0" || (error.response.data?.errors ?? []).some(
+          (error2) => error2.type === "RATE_LIMITED"
+        )) {
+          const rateLimitReset = new Date(
+            ~~error.response.headers["x-ratelimit-reset"] * 1e3
+          ).getTime();
+          const retryAfter2 = Math.max(
+            // Add one second so we retry _after_ the reset time
+            // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
+            Math.ceil((rateLimitReset - Date.now()) / 1e3) + 1,
+            0
+          );
+          const wantRetry2 = await emitter.trigger(
+            "rate-limit",
+            retryAfter2,
+            options,
+            octokit,
+            retryCount
+          );
+          return { wantRetry: wantRetry2, retryAfter: retryAfter2 };
+        }
+        return {};
+      })();
+      if (wantRetry) {
+        request2.retryCount++;
+        return retryAfter * state2.retryAfterBaseValue;
+      }
+    });
+  };
+  octokit.hook.wrap("request", (request2, options) => {
+    initializeBottleneck();
+    return wrapRequest2(state, request2, options);
   });
-  octokit.hook.wrap("request", wrapRequest2.bind(null, state));
   return {};
 }
 var import_light2, VERSION8, noop3, triggers_notification_paths_default, regex, triggersNotification, groups, createGroups;
@@ -28922,7 +28950,13 @@ var init_dist_src4 = __esm({
 // npm/node_modules/@octokit/oauth-methods/dist-bundle/index.js
 function requestToOAuthBaseUrl(request2) {
   const endpointDefaults = request2.endpoint.DEFAULTS;
-  return /^https:\/\/(api\.)?github\.com$/.test(endpointDefaults.baseUrl) ? "https://github.com" : endpointDefaults.baseUrl.replace("/api/v3", "");
+  if (/^https:\/\/(api\.)?github\.com$/.test(endpointDefaults.baseUrl)) {
+    return "https://github.com";
+  }
+  if (/^https:\/\/api\..*\.ghe\.com$/.test(endpointDefaults.baseUrl)) {
+    return endpointDefaults.baseUrl.replace("api.", "");
+  }
+  return endpointDefaults.baseUrl.replace("/api/v3", "");
 }
 async function oauthRequest(request2, route, parameters) {
   const withOAuthParameters = {
@@ -30357,7 +30391,7 @@ var init_dist_node = __esm({
     ];
     REGEX = routeMatcher2(PATHS);
     FIVE_SECONDS_IN_MS = 5 * 1e3;
-    VERSION12 = "8.2.0";
+    VERSION12 = "8.3.0";
   }
 });
 
@@ -31025,7 +31059,7 @@ var init_dist_node3 = __esm({
     init_dist_node2();
     init_dist_bundle9();
     init_dist_node2();
-    VERSION13 = "8.0.3";
+    VERSION13 = "8.0.4";
     OAuthAppOctokit = Octokit.defaults({
       userAgent: `octokit-oauth-app.js/${VERSION13} ${getUserAgent()}`
     });
@@ -31972,6 +32006,127 @@ var init_dist_bundle13 = __esm({
   }
 });
 
+// npm/node_modules/@octokit/app/node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js
+function normalizePaginatedListResponse2(response) {
+  if (!response.data) {
+    return {
+      ...response,
+      data: []
+    };
+  }
+  const responseNeedsNormalization = ("total_count" in response.data || "total_commits" in response.data) && !("url" in response.data);
+  if (!responseNeedsNormalization) return response;
+  const incompleteResults = response.data.incomplete_results;
+  const repositorySelection = response.data.repository_selection;
+  const totalCount = response.data.total_count;
+  const totalCommits = response.data.total_commits;
+  delete response.data.incomplete_results;
+  delete response.data.repository_selection;
+  delete response.data.total_count;
+  delete response.data.total_commits;
+  const namespaceKey = Object.keys(response.data)[0];
+  const data = response.data[namespaceKey];
+  response.data = data;
+  if (typeof incompleteResults !== "undefined") {
+    response.data.incomplete_results = incompleteResults;
+  }
+  if (typeof repositorySelection !== "undefined") {
+    response.data.repository_selection = repositorySelection;
+  }
+  response.data.total_count = totalCount;
+  response.data.total_commits = totalCommits;
+  return response;
+}
+function iterator2(octokit, route, parameters) {
+  const options = typeof route === "function" ? route.endpoint(parameters) : octokit.request.endpoint(route, parameters);
+  const requestMethod = typeof route === "function" ? route : octokit.request;
+  const method = options.method;
+  const headers = options.headers;
+  let url = options.url;
+  return {
+    [Symbol.asyncIterator]: () => ({
+      async next() {
+        if (!url) return { done: true };
+        try {
+          const response = await requestMethod({ method, url, headers });
+          const normalizedResponse = normalizePaginatedListResponse2(response);
+          url = ((normalizedResponse.headers.link || "").match(
+            /<([^<>]+)>;\s*rel="next"/
+          ) || [])[1];
+          if (!url && "total_commits" in normalizedResponse.data) {
+            const parsedUrl = new URL(normalizedResponse.url);
+            const params = parsedUrl.searchParams;
+            const page = parseInt(params.get("page") || "1", 10);
+            const per_page = parseInt(params.get("per_page") || "250", 10);
+            if (page * per_page < normalizedResponse.data.total_commits) {
+              params.set("page", String(page + 1));
+              url = parsedUrl.toString();
+            }
+          }
+          return { value: normalizedResponse };
+        } catch (error) {
+          if (error.status !== 409) throw error;
+          url = "";
+          return {
+            value: {
+              status: 200,
+              headers: {},
+              data: []
+            }
+          };
+        }
+      }
+    })
+  };
+}
+function paginate2(octokit, route, parameters, mapFn) {
+  if (typeof parameters === "function") {
+    mapFn = parameters;
+    parameters = void 0;
+  }
+  return gather2(
+    octokit,
+    [],
+    iterator2(octokit, route, parameters)[Symbol.asyncIterator](),
+    mapFn
+  );
+}
+function gather2(octokit, results, iterator22, mapFn) {
+  return iterator22.next().then((result) => {
+    if (result.done) {
+      return results;
+    }
+    let earlyExit = false;
+    function done() {
+      earlyExit = true;
+    }
+    results = results.concat(
+      mapFn ? mapFn(result.value, done) : result.value.data
+    );
+    if (earlyExit) {
+      return results;
+    }
+    return gather2(octokit, results, iterator22, mapFn);
+  });
+}
+function paginateRest2(octokit) {
+  return {
+    paginate: Object.assign(paginate2.bind(null, octokit), {
+      iterator: iterator2.bind(null, octokit)
+    })
+  };
+}
+var VERSION15, composePaginateRest2;
+var init_dist_bundle14 = __esm({
+  "npm/node_modules/@octokit/app/node_modules/@octokit/plugin-paginate-rest/dist-bundle/index.js"() {
+    VERSION15 = "0.0.0-development";
+    composePaginateRest2 = Object.assign(paginate2, {
+      iterator: iterator2
+    });
+    paginateRest2.VERSION = VERSION15;
+  }
+});
+
 // npm/node_modules/@octokit/app/dist-node/index.js
 function webhooks(appOctokit, options) {
   return new Webhooks({
@@ -32046,11 +32201,11 @@ async function eachInstallation(app, callback) {
 function eachInstallationIterator(app) {
   return {
     async *[Symbol.asyncIterator]() {
-      const iterator2 = composePaginateRest.iterator(
+      const iterator3 = composePaginateRest2.iterator(
         app.octokit,
         "GET /app/installations"
       );
-      for await (const { data: installations } of iterator2) {
+      for await (const { data: installations } of iterator3) {
         for (const installation of installations) {
           const installationOctokit = await getInstallationOctokit(
             app,
@@ -32094,9 +32249,9 @@ function singleInstallationIterator(app, installationId) {
 function eachRepositoryIterator(app, query) {
   return {
     async *[Symbol.asyncIterator]() {
-      const iterator2 = query ? singleInstallationIterator(app, query.installationId) : app.eachInstallation.iterator();
-      for await (const { octokit } of iterator2) {
-        const repositoriesIterator = composePaginateRest.iterator(
+      const iterator3 = query ? singleInstallationIterator(app, query.installationId) : app.eachInstallation.iterator();
+      for await (const { octokit } of iterator3) {
+        const repositoriesIterator = composePaginateRest2.iterator(
           octokit,
           "GET /installation/repositories"
         );
@@ -32184,7 +32339,7 @@ async function middleware(pathPrefix, webhooksMiddleware, oauthMiddleware, reque
     return false;
   }
 }
-var VERSION15, App;
+var VERSION16, App;
 var init_dist_node5 = __esm({
   "npm/node_modules/@octokit/app/dist-node/index.js"() {
     init_dist_src2();
@@ -32193,14 +32348,14 @@ var init_dist_node5 = __esm({
     init_dist_node();
     init_dist_node2();
     init_dist_bundle13();
-    init_dist_bundle5();
+    init_dist_bundle14();
     init_dist_node();
-    init_dist_bundle5();
+    init_dist_bundle14();
     init_dist_node3();
     init_dist_bundle13();
-    VERSION15 = "16.1.2";
+    VERSION16 = "16.1.4";
     App = class {
-      static VERSION = VERSION15;
+      static VERSION = VERSION16;
       static defaults(defaults) {
         const AppWithDefaults = class extends this {
           constructor(...args) {
@@ -32320,8 +32475,8 @@ function onSecondaryRateLimit(retryAfter, options, octokit) {
     return true;
   }
 }
-var VERSION16, Octokit2, App2, OAuthApp2;
-var init_dist_bundle14 = __esm({
+var VERSION17, Octokit2, App2, OAuthApp2;
+var init_dist_bundle15 = __esm({
   "npm/node_modules/octokit/dist-bundle/index.js"() {
     init_dist_src2();
     init_dist_bundle5();
@@ -32333,7 +32488,7 @@ var init_dist_bundle14 = __esm({
     init_dist_node5();
     init_dist_node3();
     init_dist_node5();
-    VERSION16 = "0.0.0-development";
+    VERSION17 = "0.0.0-development";
     Octokit2 = Octokit.plugin(
       restEndpointMethods,
       paginateRest,
@@ -32341,7 +32496,7 @@ var init_dist_bundle14 = __esm({
       retry,
       throttling
     ).defaults({
-      userAgent: `octokit.js/${VERSION16}`,
+      userAgent: `octokit.js/${VERSION17}`,
       throttle: {
         onRateLimit,
         onSecondaryRateLimit
@@ -32396,7 +32551,7 @@ var core = __importStar(require_core());
 var exec = __importStar(require_exec());
 var tc = __importStar(require_tool_cache());
 var semver = __importStar(require_mod());
-var octokit_1 = (init_dist_bundle14(), __toCommonJS(dist_bundle_exports3));
+var octokit_1 = (init_dist_bundle15(), __toCommonJS(dist_bundle_exports3));
 async function resolveVersion(gh, version) {
   if (version === "*") {
     const resp = await gh.rest.repos.getLatestRelease({
@@ -32543,6 +32698,23 @@ content-type/dist/index.js:
   (* v8 ignore next -- @preserve *)
   (* v8 ignore else -- @preserve *)
 
+@octokit/graphql/dist-bundle/index.js:
+  (* v8 ignore if -- @preserve *)
+
+@octokit/oauth-methods/dist-bundle/index.js:
+  (* v8 ignore next: we always pass a custom request in tests -- @preserve *)
+
+@octokit/auth-oauth-device/dist-bundle/index.js:
+  (* v8 ignore next 2 -- @preserve *)
+
+@octokit/auth-oauth-user/dist-bundle/index.js:
+  (* v8 ignore if -- @preserve *)
+  (* v8 ignore next -- @preserve *)
+
+@octokit/auth-oauth-app/dist-bundle/index.js:
+@octokit/plugin-paginate-rest/dist-bundle/index.js:
+  (* v8 ignore next -- @preserve *)
+
 toad-cache/dist/toad-cache.mjs:
   (**
    * toad-cache
@@ -32551,6 +32723,12 @@ toad-cache/dist/toad-cache.mjs:
    * @license MIT
    * @version 3.7.3
    *)
+
+@octokit/auth-app/dist-node/index.js:
+  (* v8 ignore next - permissions are optional per OpenAPI spec, but we think that is incorrect -- @preserve *)
+  (* v8 ignore next - repositorySelection are optional per OpenAPI spec, but we think that is incorrect -- @preserve *)
+  (* v8 ignore start - due to skipped tests, see https://github.com/octokit/auth-app.js/pull/580 -- @preserve *)
+  (* v8 ignore end -- @preserve *)
 
 octokit/dist-bundle/index.js:
   (* v8 ignore next no need to test internals of the throttle plugin -- @preserve *)

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -20,7 +20,7 @@
     },
     "node_modules/@actions/core": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmmirror.com/@actions/core/-/core-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "license": "MIT",
       "dependencies": {
@@ -30,7 +30,7 @@
     },
     "node_modules/@actions/exec": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/@actions/exec/-/exec-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
       "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "license": "MIT",
       "dependencies": {
@@ -39,7 +39,7 @@
     },
     "node_modules/@actions/http-client": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmmirror.com/@actions/http-client/-/http-client-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "license": "MIT",
       "dependencies": {
@@ -49,13 +49,13 @@
     },
     "node_modules/@actions/io": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmmirror.com/@actions/io/-/io-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
       "license": "MIT"
     },
     "node_modules/@actions/tool-cache": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/@actions/tool-cache/-/tool-cache-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-2.0.2.tgz",
       "integrity": "sha512-fBhNNOWxuoLxztQebpOaWu6WeVmuwa77Z+DxIZ1B+OYvGkGQon6kTVg6Z32Cb13WCuw0szqonK+hh03mJV7Z6w==",
       "license": "MIT",
       "dependencies": {
@@ -68,7 +68,7 @@
     },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmmirror.com/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "license": "MIT",
       "engines": {
@@ -77,7 +77,7 @@
     },
     "node_modules/@octokit/app": {
       "version": "16.1.4",
-      "resolved": "https://registry.npmmirror.com/@octokit/app/-/app-16.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-16.1.4.tgz",
       "integrity": "sha512-g70WONQyGoBgqIJtv4O0MUEfOF1iJpTfFt3qAW7HaiwiJ6k607xg/gBezCa4tuq6BpO6qXn7qvq8v9tjWtgGQg==",
       "license": "MIT",
       "dependencies": {
@@ -95,13 +95,13 @@
     },
     "node_modules/@octokit/app/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/app/node_modules/@octokit/plugin-paginate-rest": {
       "version": "15.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-15.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-15.0.0.tgz",
       "integrity": "sha512-lw9A9YL5s4VPj+VEx8uMxaxQm2YTgrPDkrLEuZuu18R8TK3oPcXF4K6t52nx6xn1RcogZC9i188sAr/4XYJaQQ==",
       "license": "MIT",
       "dependencies": {
@@ -116,7 +116,7 @@
     },
     "node_modules/@octokit/app/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -125,7 +125,7 @@
     },
     "node_modules/@octokit/auth-app": {
       "version": "8.3.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/auth-app/-/auth-app-8.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.3.0.tgz",
       "integrity": "sha512-/UaKmJCsOc5XBZwhnFiGNdLH/FkDF8lYtBn1QlKxtX7IpgaRB/XOXjixFtERAknyUZHxp3oDuoiG0En4VptJSg==",
       "license": "MIT",
       "dependencies": {
@@ -144,13 +144,13 @@
     },
     "node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/auth-app/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -159,7 +159,7 @@
     },
     "node_modules/@octokit/auth-oauth-app": {
       "version": "9.0.4",
-      "resolved": "https://registry.npmmirror.com/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.4.tgz",
       "integrity": "sha512-Pe3du5LrC6dlv10b0RbarBlJtIT1Urq8BFoQklK8WmBw8YKnGgrANn7cQmHiA1v8AVihgi7YutV8MncP57I4og==",
       "license": "MIT",
       "dependencies": {
@@ -175,13 +175,13 @@
     },
     "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -190,7 +190,7 @@
     },
     "node_modules/@octokit/auth-oauth-device": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmmirror.com/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.4.tgz",
       "integrity": "sha512-M/+34rmkxMvUnnTo/uqNeVRCXJoJ+5N34eNTbL1KMtIyJpedCTsu/iFL1cWdL+w5hQMlYt6xzXoyux2gn0OVnw==",
       "license": "MIT",
       "dependencies": {
@@ -205,13 +205,13 @@
     },
     "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -220,7 +220,7 @@
     },
     "node_modules/@octokit/auth-oauth-user": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmmirror.com/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.3.tgz",
       "integrity": "sha512-t4OKUhrI5britmpRiSzPAz1TJPyUN/Hw1HEE3Hz/uElxcmnf/YCRSKtFRNc5gy4yJFTlXgk34H1lvxiotQJQvQ==",
       "license": "MIT",
       "dependencies": {
@@ -236,13 +236,13 @@
     },
     "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -251,7 +251,7 @@
     },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
       "license": "MIT",
       "engines": {
@@ -260,7 +260,7 @@
     },
     "node_modules/@octokit/auth-unauthenticated": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmmirror.com/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.4.tgz",
       "integrity": "sha512-j4zgVdP8C8C53PNsj4LLI+WFtoykaQARwwrIBILTdxwZ2Ljaa9YUxb1yQ7/seGVnmWPdC3OBefX3LLbh28gKtw==",
       "license": "MIT",
       "dependencies": {
@@ -273,13 +273,13 @@
     },
     "node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -288,7 +288,7 @@
     },
     "node_modules/@octokit/core": {
       "version": "7.0.7",
-      "resolved": "https://registry.npmmirror.com/@octokit/core/-/core-7.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.7.tgz",
       "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
       "license": "MIT",
       "dependencies": {
@@ -306,13 +306,13 @@
     },
     "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/core/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -321,7 +321,7 @@
     },
     "node_modules/@octokit/endpoint": {
       "version": "11.0.4",
-      "resolved": "https://registry.npmmirror.com/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.4.tgz",
       "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
       "license": "MIT",
       "dependencies": {
@@ -334,13 +334,13 @@
     },
     "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -349,7 +349,7 @@
     },
     "node_modules/@octokit/graphql": {
       "version": "9.0.4",
-      "resolved": "https://registry.npmmirror.com/@octokit/graphql/-/graphql-9.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.4.tgz",
       "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
       "license": "MIT",
       "dependencies": {
@@ -363,13 +363,13 @@
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -378,7 +378,7 @@
     },
     "node_modules/@octokit/oauth-app": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmmirror.com/@octokit/oauth-app/-/oauth-app-8.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-8.0.4.tgz",
       "integrity": "sha512-Ji5JpRwAJcbOJkO4ij0tW6+GrQ8efpICnAca3o5xI8/HUNjqJu3hhG4cCZdXAHMKaOaQTFX0Yl+cpu61Rsx94A==",
       "license": "MIT",
       "dependencies": {
@@ -397,7 +397,7 @@
     },
     "node_modules/@octokit/oauth-authorization-url": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
       "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
       "license": "MIT",
       "engines": {
@@ -406,7 +406,7 @@
     },
     "node_modules/@octokit/oauth-methods": {
       "version": "6.0.4",
-      "resolved": "https://registry.npmmirror.com/@octokit/oauth-methods/-/oauth-methods-6.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.4.tgz",
       "integrity": "sha512-96RsnxS7Hk/BQhUA1Qo2pmcYP6LWQRWMdo7bVbNE7ZCkFLhSUYBXVUj9tVnvhl4jzbwHYt/dcIG+ioY427b2sg==",
       "license": "MIT",
       "dependencies": {
@@ -421,13 +421,13 @@
     },
     "node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -436,19 +436,19 @@
     },
     "node_modules/@octokit/openapi-types": {
       "version": "27.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
       "license": "MIT"
     },
     "node_modules/@octokit/openapi-webhooks-types": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
       "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-graphql": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
       "integrity": "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==",
       "license": "MIT",
       "engines": {
@@ -460,7 +460,7 @@
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
       "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "license": "MIT",
       "dependencies": {
@@ -475,7 +475,7 @@
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
       "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
       "license": "MIT",
       "dependencies": {
@@ -490,7 +490,7 @@
     },
     "node_modules/@octokit/plugin-retry": {
       "version": "8.1.1",
-      "resolved": "https://registry.npmmirror.com/@octokit/plugin-retry/-/plugin-retry-8.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.1.1.tgz",
       "integrity": "sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==",
       "license": "MIT",
       "dependencies": {
@@ -507,13 +507,13 @@
     },
     "node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -522,7 +522,7 @@
     },
     "node_modules/@octokit/plugin-throttling": {
       "version": "11.0.5",
-      "resolved": "https://registry.npmmirror.com/@octokit/plugin-throttling/-/plugin-throttling-11.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-11.0.5.tgz",
       "integrity": "sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==",
       "license": "MIT",
       "dependencies": {
@@ -538,13 +538,13 @@
     },
     "node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -553,7 +553,7 @@
     },
     "node_modules/@octokit/request": {
       "version": "10.0.13",
-      "resolved": "https://registry.npmmirror.com/@octokit/request/-/request-10.0.13.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.13.tgz",
       "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
       "license": "MIT",
       "dependencies": {
@@ -570,7 +570,7 @@
     },
     "node_modules/@octokit/request-error": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmmirror.com/@octokit/request-error/-/request-error-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.1.tgz",
       "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
       "license": "MIT",
       "dependencies": {
@@ -582,13 +582,13 @@
     },
     "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/request-error/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -597,13 +597,13 @@
     },
     "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
       "version": "28.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
       "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
       "license": "MIT"
     },
     "node_modules/@octokit/request/node_modules/@octokit/types": {
       "version": "17.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-17.0.0.tgz",
       "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
       "license": "MIT",
       "dependencies": {
@@ -612,7 +612,7 @@
     },
     "node_modules/@octokit/types": {
       "version": "16.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-16.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "license": "MIT",
       "dependencies": {
@@ -621,7 +621,7 @@
     },
     "node_modules/@octokit/webhooks": {
       "version": "14.2.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/webhooks/-/webhooks-14.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
       "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
       "license": "MIT",
       "dependencies": {
@@ -635,7 +635,7 @@
     },
     "node_modules/@octokit/webhooks-methods": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
       "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
       "license": "MIT",
       "engines": {
@@ -644,13 +644,13 @@
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.162",
-      "resolved": "https://registry.npmmirror.com/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
       "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.43",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.19.43.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
@@ -660,19 +660,19 @@
     },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
-      "resolved": "https://registry.npmmirror.com/bottleneck/-/bottleneck-2.19.5.tgz",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "license": "MIT"
     },
     "node_modules/content-type": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
@@ -685,13 +685,13 @@
     },
     "node_modules/json-with-bigint": {
       "version": "3.5.11",
-      "resolved": "https://registry.npmmirror.com/json-with-bigint/-/json-with-bigint-3.5.11.tgz",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.11.tgz",
       "integrity": "sha512-WvkM9Hfb9kqzCcbsvpwfWDvdfGZDhYuCoaCwHRe5q3LtULKkbrI/L6JYcN8owflgA3di5dP2yVAV2NVCXkgtkA==",
       "license": "MIT"
     },
     "node_modules/octokit": {
       "version": "5.0.5",
-      "resolved": "https://registry.npmmirror.com/octokit/-/octokit-5.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-5.0.5.tgz",
       "integrity": "sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==",
       "license": "MIT",
       "dependencies": {
@@ -713,14 +713,14 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
@@ -729,7 +729,7 @@
     },
     "node_modules/toad-cache": {
       "version": "3.7.4",
-      "resolved": "https://registry.npmmirror.com/toad-cache/-/toad-cache-3.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
       "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
       "license": "MIT",
       "engines": {
@@ -738,7 +738,7 @@
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmmirror.com/tunnel/-/tunnel-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "license": "MIT",
       "engines": {
@@ -747,7 +747,7 @@
     },
     "node_modules/undici": {
       "version": "5.29.0",
-      "resolved": "https://registry.npmmirror.com/undici/-/undici-5.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
       "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "license": "MIT",
       "dependencies": {
@@ -759,20 +759,20 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmmirror.com/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
       "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmmirror.com/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "license": "ISC"
     }

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,0 +1,780 @@
+{
+  "name": "setup-flatc",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "setup-flatc",
+      "version": "0.0.0",
+      "dependencies": {
+        "@actions/core": "^1.11.1",
+        "@actions/exec": "^1.1.1",
+        "@actions/tool-cache": "^2.0.2",
+        "octokit": "^5.0.5"
+      },
+      "devDependencies": {
+        "@types/node": "^20.9.0",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmmirror.com/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmmirror.com/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@actions/tool-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/@actions/tool-cache/-/tool-cache-2.0.2.tgz",
+      "integrity": "sha512-fBhNNOWxuoLxztQebpOaWu6WeVmuwa77Z+DxIZ1B+OYvGkGQon6kTVg6Z32Cb13WCuw0szqonK+hh03mJV7Z6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.11.1",
+        "@actions/exec": "^1.0.0",
+        "@actions/http-client": "^2.0.1",
+        "@actions/io": "^1.1.1",
+        "semver": "^6.1.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@octokit/app": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmmirror.com/@octokit/app/-/app-16.1.4.tgz",
+      "integrity": "sha512-g70WONQyGoBgqIJtv4O0MUEfOF1iJpTfFt3qAW7HaiwiJ6k607xg/gBezCa4tuq6BpO6qXn7qvq8v9tjWtgGQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-app": "^8.3.0",
+        "@octokit/auth-unauthenticated": "^7.0.4",
+        "@octokit/core": "^7.0.7",
+        "@octokit/oauth-app": "^8.0.4",
+        "@octokit/plugin-paginate-rest": "^15.0.0",
+        "@octokit/types": "^17.0.0",
+        "@octokit/webhooks": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/app/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/app/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-15.0.0.tgz",
+      "integrity": "sha512-lw9A9YL5s4VPj+VEx8uMxaxQm2YTgrPDkrLEuZuu18R8TK3oPcXF4K6t52nx6xn1RcogZC9i188sAr/4XYJaQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/app/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/auth-app/-/auth-app-8.3.0.tgz",
+      "integrity": "sha512-/UaKmJCsOc5XBZwhnFiGNdLH/FkDF8lYtBn1QlKxtX7IpgaRB/XOXjixFtERAknyUZHxp3oDuoiG0En4VptJSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.4",
+        "@octokit/auth-oauth-user": "^6.0.3",
+        "@octokit/request": "^10.0.13",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmmirror.com/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.4.tgz",
+      "integrity": "sha512-Pe3du5LrC6dlv10b0RbarBlJtIT1Urq8BFoQklK8WmBw8YKnGgrANn7cQmHiA1v8AVihgi7YutV8MncP57I4og==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.4",
+        "@octokit/auth-oauth-user": "^6.0.3",
+        "@octokit/request": "^10.0.13",
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmmirror.com/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.4.tgz",
+      "integrity": "sha512-M/+34rmkxMvUnnTo/uqNeVRCXJoJ+5N34eNTbL1KMtIyJpedCTsu/iFL1cWdL+w5hQMlYt6xzXoyux2gn0OVnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.3",
+        "@octokit/request": "^10.0.13",
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.3.tgz",
+      "integrity": "sha512-t4OKUhrI5britmpRiSzPAz1TJPyUN/Hw1HEE3Hz/uElxcmnf/YCRSKtFRNc5gy4yJFTlXgk34H1lvxiotQJQvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.4",
+        "@octokit/oauth-methods": "^6.0.3",
+        "@octokit/request": "^10.0.13",
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmmirror.com/@octokit/auth-unauthenticated/-/auth-unauthenticated-7.0.4.tgz",
+      "integrity": "sha512-j4zgVdP8C8C53PNsj4LLI+WFtoykaQARwwrIBILTdxwZ2Ljaa9YUxb1yQ7/seGVnmWPdC3OBefX3LLbh28gKtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-unauthenticated/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmmirror.com/@octokit/core/-/core-7.0.7.tgz",
+      "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.4",
+        "@octokit/request": "^10.0.13",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmmirror.com/@octokit/endpoint/-/endpoint-11.0.4.tgz",
+      "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmmirror.com/@octokit/graphql/-/graphql-9.0.4.tgz",
+      "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.13",
+        "@octokit/types": "^17.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/oauth-app": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmmirror.com/@octokit/oauth-app/-/oauth-app-8.0.4.tgz",
+      "integrity": "sha512-Ji5JpRwAJcbOJkO4ij0tW6+GrQ8efpICnAca3o5xI8/HUNjqJu3hhG4cCZdXAHMKaOaQTFX0Yl+cpu61Rsx94A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.4",
+        "@octokit/auth-oauth-user": "^6.0.3",
+        "@octokit/auth-unauthenticated": "^7.0.4",
+        "@octokit/core": "^7.0.7",
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/oauth-methods": "^6.0.3",
+        "@types/aws-lambda": "^8.10.83",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/@octokit/oauth-methods/-/oauth-methods-6.0.4.tgz",
+      "integrity": "sha512-96RsnxS7Hk/BQhUA1Qo2pmcYP6LWQRWMdo7bVbNE7ZCkFLhSUYBXVUj9tVnvhl4jzbwHYt/dcIG+ioY427b2sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.13",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
+      "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-graphql": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-6.0.0.tgz",
+      "integrity": "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmmirror.com/@octokit/plugin-retry/-/plugin-retry-8.1.1.tgz",
+      "integrity": "sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=7"
+      }
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmmirror.com/@octokit/plugin-throttling/-/plugin-throttling-11.0.5.tgz",
+      "integrity": "sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0",
+        "bottleneck": "^2.15.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^7.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmmirror.com/@octokit/request/-/request-10.0.13.tgz",
+      "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.1.1",
+        "@octokit/types": "^17.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmmirror.com/@octokit/request-error/-/request-error-7.1.1.tgz",
+      "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/openapi-types/-/openapi-types-28.0.0.tgz",
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-17.0.0.tgz",
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/webhooks/-/webhooks-14.2.0.tgz",
+      "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "12.1.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/webhooks-methods": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.162",
+      "resolved": "https://registry.npmmirror.com/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+      "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmmirror.com/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmmirror.com/json-with-bigint/-/json-with-bigint-3.5.11.tgz",
+      "integrity": "sha512-WvkM9Hfb9kqzCcbsvpwfWDvdfGZDhYuCoaCwHRe5q3LtULKkbrI/L6JYcN8owflgA3di5dP2yVAV2NVCXkgtkA==",
+      "license": "MIT"
+    },
+    "node_modules/octokit": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmmirror.com/octokit/-/octokit-5.0.5.tgz",
+      "integrity": "sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/app": "^16.1.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/oauth-app": "^8.0.3",
+        "@octokit/plugin-paginate-graphql": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/plugin-retry": "^8.0.3",
+        "@octokit/plugin-throttling": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "@octokit/webhooks": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmmirror.com/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmmirror.com/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmmirror.com/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmmirror.com/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -7,7 +7,10 @@ const lockPath = "./npm/package-lock.json";
 let lockContent: string | undefined;
 try {
   lockContent = await Deno.readTextFile(lockPath);
-} catch {
+} catch (err) {
+  if (!(err instanceof Deno.errors.NotFound)) {
+    throw err;
+  }
   // no lock file yet (first build)
 }
 

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -1,8 +1,22 @@
 import * as dnt from "@deno/dnt";
 import * as esbuild from "esbuild";
 
+// Preserve the committed package-lock.json so that dnt's `npm install` resolves
+// the same (transitive) dependency versions on every build.
+const lockPath = "./npm/package-lock.json";
+let lockContent: string | undefined;
+try {
+  lockContent = await Deno.readTextFile(lockPath);
+} catch {
+  // no lock file yet (first build)
+}
+
 await dnt.emptyDir("./npm");
 await dnt.emptyDir("./dist");
+
+if (lockContent != null) {
+  await Deno.writeTextFile(lockPath, lockContent);
+}
 
 await dnt.build({
   entryPoints: ["./src/main.ts"],


### PR DESCRIPTION
## Overview

Three CI-related changes:

1. Add Dependabot version-update support for the Deno ecosystem
2. Fix `dist/main.js` non-reproducibility that caused CI failures
3. Reduce auto-update schedule from monthly to quarterly

## Background

CI fails on dependency updates even though `deno.lock` is present. Root cause: `deno.lock` only pins the dependencies Deno resolves (`jsr:`/`npm:` import chains), while the `npm install` run internally by dnt in `scripts/bundle.ts` resolves the latest transitive dependency versions from the npm registry (e.g. `json-with-bigint`). Whenever such a transitive dependency releases a new version, `dist/main.js` drifts and the CI `assert_unchanged` check fails.

## Changes

| File | Change |
|---|---|
| `.github/dependabot.yml` | Add `deno` package ecosystem (directory `/`, monthly, grouped into a single PR) |
| `scripts/bundle.ts` | Preserve and reuse `npm/package-lock.json` across builds so `npm install` installs pinned versions; only swallow `NotFound` errors when restoring the lockfile |
| `.gitignore` | Track `npm/package-lock.json` in version control |
| `npm/package-lock.json` | New; pins the entire npm transitive dependency tree (e.g. `json-with-bigint@3.5.11`), resolved via the official npm registry |
| `dist/main.js` | Regenerated against the pinned dependency versions |
| `.github/workflows/auto-update.yml` | Schedule changed from monthly `0 0 1 * *` to quarterly `0 0 1 */3 *` |

## Verification

- `just ci` passes locally (working tree clean after build)
- Two consecutive builds produce identical output (idempotent); `dist/main.js` no longer drifts when npm transitive dependencies are released
- Simulated the full auto-update flow (`deno update` + `just dev` + `just bundle`): no diff produced
- Real dependency updates are still picked up and committed (`package-lock.json` + `dist/main.js`) by auto-update

## Notes

- The committed `package-lock.json` uses the official npm registry (`registry.npmjs.org`) for all `resolved` URLs
- Addressed Copilot review feedback (both review threads resolved)
- auto-update is kept: it refreshes bundle artifacts after dependency updates, which Dependabot does not cover
